### PR TITLE
Update hcadfstreamforpbi.usql

### DIFF
--- a/Azure Data Lake/ManualDeploymentGuide/scripts/datafactory/scripts_blob/hcadfstreamforpbi.usql
+++ b/Azure Data Lake/ManualDeploymentGuide/scripts/datafactory/scripts_blob/hcadfstreamforpbi.usql
@@ -180,6 +180,7 @@ Par,
 	V52  string,
 	V53  string,
 	V54  string
+	READONLY Par
 	USING new Extension.R.Reducer(scriptFile:@RScriptName, rReturnType:"dataframe");
 
 


### PR DESCRIPTION
This script failed on execution with the following error: 

Error in Activity: [{"diagnosticCode":223412291,"severity":"Error","component":"Runtime","source":"User","errorId":"VertexFailedFast","message":"Vertex failed with a fail-fast error","description":"Vertex failure triggered quick job abort. Vertex failed: SV19_Process[0] with error: Vertex user code error.","resolution":"","helpLink":"","details":"","userData":"","innerError":{"diagnosticCode":195887158,"severity":"Error","component":"RUNTIME","source":"User","errorId":"E_RUNTIME_USER_UNHANDLED_EXCEPTION_FROM_USER_CODE","message":"An unhandled exception from user code has been reported when invoking the method 'Reduce' on the user type 'Extension.R.Reducer'","description":"Unhandled exception from user code: \"Output column 'Par' is missing from the data frame\"\nThe details includes more information including any inner exceptions and the stack trace where the exception was raised.","resolution":"Make sure the bug in the user code is fixed.","helpLink":"","details":"==== Caught exception System.Exception\n\n at Extension.R.UsqlHelperFunctions.<CreateAndProcessDataFrame>d__1.MoveNext() in C:\\agent_1\\USqlExtensions\\lang\\R\\ExtR\\UsqlHelperFunctions.cs:line 52\r\n at ScopeEngine.RunUdoCodeExceptionhandled<class <lambda_13685103f08d8cd53bb8dd64f078082a> >(ScopeTypedManagedHandle<System::String ^>* className, SByte* methodName, <lambda_13685103f08d8cd53bb8dd64f078082a>* code) in d:\\data\\yarnnm\\local\\usercache\\cc81f23a-7061-421d-afb7-ae00184f266d\\appcache\\application_1543548472050_79687\\container_e338_1543548472050_79687_01_000001\\wd\\managed.h:line 2034","userData":""}}].

After adding the READONLY Par clause to the REDUCE expression, the activity executes successfully.